### PR TITLE
support for PreProcessChannel without support for meanData

### DIFF
--- a/src/preprocess_info.cc
+++ b/src/preprocess_info.cc
@@ -1,4 +1,5 @@
 #include "preprocess_info.h"
+#include "blob.h"
 #include "utils.h"
 
 #include <napi.h>
@@ -17,14 +18,23 @@ void PreProcessInfo::Init(const Napi::Env& env) {
 
   Napi::Function func = DefineClass(
       env, "PreProcessInfo",
-      {InstanceMethod("getColorFormat", &PreProcessInfo::GetColorFormat),
-       InstanceMethod("setColorFormat", &PreProcessInfo::SetColorFormat),
-       InstanceMethod("getResizeAlgorithm", &PreProcessInfo::GetResizeAlgorithm),
-       InstanceMethod("setResizeAlgorithm", &PreProcessInfo::SetResizeAlgorithm),
-       InstanceMethod("getMeanVariant", &PreProcessInfo::GetMeanVariant),
-       InstanceMethod("setVariant", &PreProcessInfo::SetVariant),
-       InstanceMethod("getNumberOfChannels", &PreProcessInfo::GetNumberOfChannels)
-       });
+      {
+          InstanceMethod("init", &PreProcessInfo::Init),
+          InstanceMethod("getColorFormat", &PreProcessInfo::GetColorFormat),
+          InstanceMethod("setColorFormat", &PreProcessInfo::SetColorFormat),
+          InstanceMethod("getResizeAlgorithm",
+                         &PreProcessInfo::GetResizeAlgorithm),
+          InstanceMethod("setResizeAlgorithm",
+                         &PreProcessInfo::SetResizeAlgorithm),
+          InstanceMethod("getMeanVariant", &PreProcessInfo::GetMeanVariant),
+          InstanceMethod("setVariant", &PreProcessInfo::SetVariant),
+          InstanceMethod("getNumberOfChannels",
+                         &PreProcessInfo::GetNumberOfChannels),
+          InstanceMethod("getPreProcessChannel",
+                         &PreProcessInfo::GetPreProcessChannel),
+          InstanceMethod("setPreProcessChannel",
+                         &PreProcessInfo::SetPreProcessChannel),
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -41,6 +51,28 @@ Napi::Object PreProcessInfo::NewInstance(const Napi::Env& env,
   preInfo->_input_info = actual;
 
   return scope.Escape(napi_value(obj)).ToObject();
+}
+
+void PreProcessInfo::Init(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 1) {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (!info[0].IsNumber()) {
+    Napi::TypeError::New(env, "Wrong type of arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  size_t numOfChannels = info[0].ToNumber().Int32Value();
+
+  _input_info->getPreProcess().init(numOfChannels);
+
+  return;
 }
 
 void PreProcessInfo::SetColorFormat(const Napi::CallbackInfo& info) {
@@ -65,7 +97,8 @@ void PreProcessInfo::SetColorFormat(const Napi::CallbackInfo& info) {
     return;
   }
 
-  _input_info->getPreProcess().setColorFormat(utils::GetColorFormatByName(colorFormatName));
+  _input_info->getPreProcess().setColorFormat(
+      utils::GetColorFormatByName(colorFormatName));
 }
 
 Napi::Value PreProcessInfo::GetColorFormat(const Napi::CallbackInfo& info) {
@@ -75,19 +108,21 @@ Napi::Value PreProcessInfo::GetColorFormat(const Napi::CallbackInfo& info) {
     return Napi::Object::New(env);
   }
 
-  return Napi::String::New(
-      env, utils::GetNameOfColorFormat(_input_info->getPreProcess().getColorFormat()));
+  return Napi::String::New(env,
+                           utils::GetNameOfColorFormat(
+                               _input_info->getPreProcess().getColorFormat()));
 }
 
-Napi::Value PreProcessInfo::GetNumberOfChannels(const Napi::CallbackInfo& info) {
+Napi::Value PreProcessInfo::GetNumberOfChannels(
+    const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() > 0) {
     Napi::TypeError::New(env, "Invalid argument").ThrowAsJavaScriptException();
     return Napi::Object::New(env);
   }
 
-  return Napi::Number::New(
-      env, _input_info->getPreProcess().getNumberOfChannels());
+  return Napi::Number::New(env,
+                           _input_info->getPreProcess().getNumberOfChannels());
 }
 
 void PreProcessInfo::SetResizeAlgorithm(const Napi::CallbackInfo& info) {
@@ -112,7 +147,8 @@ void PreProcessInfo::SetResizeAlgorithm(const Napi::CallbackInfo& info) {
     return;
   }
 
-  _input_info->getPreProcess().setResizeAlgorithm(utils::GetResizeAlgorithmByName(resizeAlgorithm));
+  _input_info->getPreProcess().setResizeAlgorithm(
+      utils::GetResizeAlgorithmByName(resizeAlgorithm));
 }
 
 Napi::Value PreProcessInfo::GetResizeAlgorithm(const Napi::CallbackInfo& info) {
@@ -123,7 +159,8 @@ Napi::Value PreProcessInfo::GetResizeAlgorithm(const Napi::CallbackInfo& info) {
   }
 
   return Napi::String::New(
-      env, utils::GetNameOfResizeAlgorithm(_input_info->getPreProcess().getResizeAlgorithm()));
+      env, utils::GetNameOfResizeAlgorithm(
+               _input_info->getPreProcess().getResizeAlgorithm()));
 }
 
 void PreProcessInfo::SetVariant(const Napi::CallbackInfo& info) {
@@ -148,7 +185,8 @@ void PreProcessInfo::SetVariant(const Napi::CallbackInfo& info) {
     return;
   }
 
-  _input_info->getPreProcess().setVariant(utils::GetMeanVariantByName(meanvariant));
+  _input_info->getPreProcess().setVariant(
+      utils::GetMeanVariantByName(meanvariant));
 }
 
 Napi::Value PreProcessInfo::GetMeanVariant(const Napi::CallbackInfo& info) {
@@ -158,7 +196,106 @@ Napi::Value PreProcessInfo::GetMeanVariant(const Napi::CallbackInfo& info) {
     return Napi::Object::New(env);
   }
 
-  return Napi::String::New(
-      env, utils::GetNameOfMeanVariant(_input_info->getPreProcess().getMeanVariant()));
+  return Napi::String::New(env,
+                           utils::GetNameOfMeanVariant(
+                               _input_info->getPreProcess().getMeanVariant()));
 }
+
+Napi::Value PreProcessInfo::GetPreProcessChannel(
+    const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 1) {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+    return Napi::Object::New(env);
+    ;
+  }
+
+  if (!info[0].IsNumber()) {
+    Napi::TypeError::New(env, "Wrong type of arguments")
+        .ThrowAsJavaScriptException();
+    return Napi::Object::New(env);
+    ;
+  }
+
+  size_t index = info[0].ToNumber().Int32Value();
+  ie::PreProcessInfo& preInfo = _input_info->getPreProcess();
+
+  size_t numberOfChannels = preInfo.getNumberOfChannels();
+
+  if (numberOfChannels == 0) {
+    Napi::Error::New(env, "accessing pre-process when nothing was set.")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  };
+
+  if (index >= numberOfChannels) {
+    std::string errorLog =
+        "pre process index " + std::to_string(index) + " is out of bounds.";
+    Napi::Error::New(env, errorLog).ThrowAsJavaScriptException();
+    return env.Null();
+  };
+
+  const ie::PreProcessChannel::Ptr& preProcessChannel = preInfo[index];
+  Napi::Object preprocess_channel = Napi::Object::New(env);
+  preprocess_channel.Set("stdScale", preProcessChannel->stdScale);
+  preprocess_channel.Set("meanValue", preProcessChannel->meanValue);
+  Napi::Value channelInfo = Napi::Value::From(env, preprocess_channel);
+  return channelInfo;
+}
+
+void PreProcessInfo::SetPreProcessChannel(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 2) {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (!info[0].IsNumber()) {
+    Napi::TypeError::New(env, "Wrong type of arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (!info[1].IsObject()) {
+    Napi::TypeError::New(env, "Wrong type of arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  size_t index = info[0].ToNumber().Int32Value();
+  Napi::Object newChannel = info[1].ToObject();
+
+  ie::PreProcessInfo& preInfo = _input_info->getPreProcess();
+
+  size_t numberOfChannels = preInfo.getNumberOfChannels();
+
+  if (numberOfChannels == 0) {
+    Napi::Error::New(env, "accessing pre-process when nothing was set.")
+        .ThrowAsJavaScriptException();
+    return;
+  };
+
+  if (index >= numberOfChannels) {
+    std::string errorLog =
+        "pre process index " + std::to_string(index) + " is out of bounds.";
+    Napi::Error::New(env, errorLog).ThrowAsJavaScriptException();
+    return;
+  };
+
+  ie::PreProcessChannel::Ptr channel = preInfo[index];
+  if (newChannel.Has("stdScale")) {
+    channel->stdScale = newChannel.Get("stdScale").ToNumber().FloatValue();
+  }
+
+  if (newChannel.Has("meanValue")) {
+    channel->meanValue = newChannel.Get("meanValue").ToNumber().FloatValue();
+  }
+
+  return;
+}
+
 }  // namespace ienodejs

--- a/src/preprocess_info.h
+++ b/src/preprocess_info.h
@@ -10,23 +10,27 @@ namespace ienodejs {
 class PreProcessInfo : public Napi::ObjectWrap<PreProcessInfo> {
  public:
   static void Init(const Napi::Env& env);
-  static Napi::Object NewInstance(
-      const Napi::Env& envs,
-      InferenceEngine::InputInfo::Ptr actual);
+  static Napi::Object NewInstance(const Napi::Env& envs,
+                                  InferenceEngine::InputInfo::Ptr actual);
   PreProcessInfo(const Napi::CallbackInfo& info);
 
  private:
   static Napi::FunctionReference constructor;
   // APIs
+
+  void Init(const Napi::CallbackInfo& info);
   void SetColorFormat(const Napi::CallbackInfo& info);
   Napi::Value GetColorFormat(const Napi::CallbackInfo& info);
-  Napi::Value GetNumberOfChannels(const Napi::CallbackInfo& info);
   void SetResizeAlgorithm(const Napi::CallbackInfo& info);
   Napi::Value GetResizeAlgorithm(const Napi::CallbackInfo& info);
   void SetVariant(const Napi::CallbackInfo& info);
   Napi::Value GetMeanVariant(const Napi::CallbackInfo& info);
 
-  InferenceEngine::InputInfo::Ptr  _input_info;
+  Napi::Value GetPreProcessChannel(const Napi::CallbackInfo& info);
+  void SetPreProcessChannel(const Napi::CallbackInfo& info);
+  Napi::Value GetNumberOfChannels(const Napi::CallbackInfo& info);
+
+  InferenceEngine::InputInfo::Ptr _input_info;
 };
 
 }  // namespace ienodejs

--- a/test/network.js
+++ b/test/network.js
@@ -6,6 +6,7 @@ var expect = chai.expect;
 var should = chai.should();
 
 const ie = require('../lib/ie');
+const {it} = require('mocha');
 
 describe('Network Test', function() {
   let network;
@@ -200,10 +201,11 @@ describe('Network Test', function() {
     expect(preprocessInfo.getColorFormat()).to.be.a('string').equal('bgr');
   });
 
-  it('PreProcessInfo.setColorFormat should throw for wrong type of argument', () => {
-    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(() => preprocessInfo.setColorFormat(1)).to.throw(TypeError);
-  });
+  it('PreProcessInfo.setColorFormat should throw for wrong type of argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setColorFormat(1)).to.throw(TypeError);
+     });
 
   it('PreProcessInfo.setColorFormat should throw for invalid argument', () => {
     const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
@@ -220,31 +222,39 @@ describe('Network Test', function() {
     expect(preprocessInfo.getResizeAlgorithm()).to.be.a('string');
   });
 
-  it('PreProcessInfo.getResizeAlgorithm should throw for invalid argument', () => {
-    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(() => preprocessInfo.getResizeAlgorithm(1)).to.throw(TypeError);
-  });
+  it('PreProcessInfo.getResizeAlgorithm should throw for invalid argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.getResizeAlgorithm(1)).to.throw(TypeError);
+     });
 
   it('PreProcessInfo.setResizeAlgorithm should be a function', () => {
     const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
     expect(preprocessInfo.setResizeAlgorithm).to.be.a('function');
   });
 
-  it('PreProcessInfo.setResizeAlgorithm should set algorithm "resize_bilinear"', () => {
-    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(preprocessInfo.setResizeAlgorithm('resize_bilinear')).to.be.a('undefined');
-    expect(preprocessInfo.getResizeAlgorithm()).to.be.a('string').equal('resize_bilinear');
-  });
+  it('PreProcessInfo.setResizeAlgorithm should set algorithm "resize_bilinear"',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(preprocessInfo.setResizeAlgorithm('resize_bilinear'))
+           .to.be.a('undefined');
+       expect(preprocessInfo.getResizeAlgorithm())
+           .to.be.a('string')
+           .equal('resize_bilinear');
+     });
 
-  it('PreProcessInfo.setResizeAlgorithm should throw for wrong type of argument', () => {
-    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(() => preprocessInfo.setResizeAlgorithm(1)).to.throw(TypeError);
-  });
+  it('PreProcessInfo.setResizeAlgorithm should throw for wrong type of argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setResizeAlgorithm(1)).to.throw(TypeError);
+     });
 
-  it('PreProcessInfo.setResizeAlgorithm should throw for invalid argument', () => {
-    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(() => preprocessInfo.setResizeAlgorithm('foo')).to.throw(TypeError);
-  });
+  it('PreProcessInfo.setResizeAlgorithm should throw for invalid argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setResizeAlgorithm('foo'))
+           .to.throw(TypeError);
+     });
 
   it('PreProcessInfo.getMeanVariant should be a function', () => {
     const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
@@ -269,17 +279,40 @@ describe('Network Test', function() {
   it('PreProcessInfo.setVariant should set type of mean "mean_value"', () => {
     const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
     expect(preprocessInfo.setVariant('mean_value')).to.be.a('undefined');
-    expect(preprocessInfo.getMeanVariant()).to.be.a('string').equal('mean_value');
+    expect(preprocessInfo.getMeanVariant())
+        .to.be.a('string')
+        .equal('mean_value');
   });
 
-  it('PreProcessInfo.setVariant should throw for wrong type of argument', () => {
-    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(() => preprocessInfo.setVariant(1)).to.throw(TypeError);
-  });
+  it('PreProcessInfo.setVariant should throw for wrong type of argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setVariant(1)).to.throw(TypeError);
+     });
 
   it('PreProcessInfo.setVariant should throw for invalid argument', () => {
     const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
     expect(() => preprocessInfo.setVariant('foo')).to.throw(TypeError);
+  });
+
+  it('PreProcessInfo.init() should be a function', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    expect(preprocessInfo.init).to.be.a('function');
+  })
+
+  it('PreProcessInfo.init should be a function', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    expect(preprocessInfo.init).to.be.a('function');
+  })
+
+  it('PreProcessInfo.init should throw for wrong number of arguments', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    expect(() => preprocessInfo.init(1, 3)).to.throw(TypeError);
+  });
+
+  it('PreProcessInfo.init should throw for invalid argument', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    expect(() => preprocessInfo.init('foo')).to.throw(TypeError);
   });
 
   it('PreProcessInfo.getNumberOfChannels should be a function', () => {
@@ -292,10 +325,93 @@ describe('Network Test', function() {
     expect(preprocessInfo.getNumberOfChannels()).to.be.a('number');
   });
 
-  it('PreProcessInfo.getNumberOfChannels should throw for invalid argument', () => {
+  it('PreProcessInfo.getNumberOfChannels should throw for invalid argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.getNumberOfChannels(1)).to.throw(TypeError);
+     });
+
+  it('PreProcessInfo.getPreProcessChannel should be a function', () => {
     const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
-    expect(() => preprocessInfo.getNumberOfChannels(1)).to.throw(TypeError);
+    expect(preprocessInfo.getPreProcessChannel).to.be.a('function');
   });
+
+  it('PreProcessChannel should throw when the number of channels is 0', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    expect(preprocessInfo.getNumberOfChannels()).to.be.a('number').equal(0);
+    expect(() => preprocessInfo.getPreProcessChannel(0)).to.throw();
+  });
+
+  it('Check the properties of PreProcessChannel', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    preprocessInfo.init(3);
+    const perProcessChannel = preprocessInfo.getPreProcessChannel(0);
+    expect(perProcessChannel).to.be.a('object');
+    expect(perProcessChannel).to.have.property('stdScale');
+    expect(perProcessChannel.stdScale).to.be.a('number');
+    expect(perProcessChannel).to.have.property('meanValue');
+    expect(perProcessChannel.meanValue).to.be.a('number');
+  });
+
+  it('PreProcessInfo.getPreProcessChannel should throw for wrong type of argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.getPreProcessChannel('foo'))
+           .to.throw(TypeError);
+     });
+
+  it('PreProcessInfo.getPreProcessChannel should throw for wrong numbers of argument',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.getPreProcessChannel(1, 2))
+           .to.throw(TypeError);
+     });
+
+  it('PreProcessInfo.setPreProcessChannel should be a function', () => {
+    const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+    expect(preprocessInfo.setPreProcessChannel).to.be.a('function');
+  });
+
+  it('PreProcessInfo.setPreProcessChannel should set the stdScale and the meanValue',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       preprocessInfo.setPreProcessChannel(
+           0, {'stdScale': 127.5, 'meanValue': 127.5});
+       const perProcessChannel = preprocessInfo.getPreProcessChannel(0);
+       expect(perProcessChannel.meanValue).to.be.a('number').equal(127.5);
+       expect(perProcessChannel.stdScale).to.be.a('number').equal(127.5);
+     });
+
+  it('PreProcessInfo.setPreProcessChannel should should throw for wrong number of arguments',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setPreProcessChannel(1)).to.throw(TypeError);
+     });
+
+  it('PreProcessInfo.setPreProcessChannel should should throw for wrong number of arguments',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(
+           () => preprocessInfo.setPreProcessChannel(
+               0, {'stdScale': 127.5, 'meanValue': 127.5}, 1))
+           .to.throw(TypeError);
+     });
+
+  it('PreProcessInfo.setPreProcessChannel should should throw for wrong type of arguments',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setPreProcessChannel('foo', {
+         'stdScale': 127.5,
+         'meanValue': 127.5
+       })).to.throw(TypeError);
+     });
+
+  it('PreProcessInfo.setPreProcessChannel should should throw for wrong type of arguments',
+     () => {
+       const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       expect(() => preprocessInfo.setPreProcessChannel('foo', 'foo2'))
+           .to.throw(TypeError);
+     });
 
   it('getOutputsInfo should be a function', () => {
     expect(network.getOutputsInfo).to.be.a('function');


### PR DESCRIPTION
#26  This PR does not support for the `meanData` in PreProcessChannel. It supports getting and setting the `stdScale` and `meanValue` successfully.