### PR TITLE
Verify the Preprocesschannel at the example hello_classification_node

### DIFF
--- a/example/hello_classification_node/main.js
+++ b/example/hello_classification_node/main.js
@@ -201,10 +201,10 @@ async function main() {
   const input_info = inputs_info[0];
   console.log(`Set input layout to 'nhwc'.`);
   input_info.setLayout('nhwc');
-  if (!preprocess) {
-    console.log(`Set input precision to 'u8'.`);
-    input_info.setPrecision('u8');
-  }
+  // if (!preprocess) {
+  //   console.log(`Set input precision to 'u8'.`);
+  //   input_info.setPrecision('u8');
+  // }
 
   const output_info = outputs_info[0];
   showBreakLine();
@@ -224,6 +224,17 @@ async function main() {
     image.resize(input_width, input_height, jimp.RESIZE_BILINEAR);
   }
   showBreakLine();
+
+  const rgb = color === 'bgr' ? {r: 2, g: 1, b: 0} : {r: 0, g: 1, b: 2};
+
+  const preProcessInfo = input_info.getPreProcess();
+  preProcessInfo.init(3);
+  console.log("Mean is : " + mean);
+  console.log("Std is : " + std);
+  preProcessInfo.setPreProcessChannel(rgb.r, {'stdScale': std[rgb.r], 'meanValue': mean[rgb.r]});
+  preProcessInfo.setPreProcessChannel(rgb.g, {'stdScale': std[rgb.g], 'meanValue': mean[rgb.g]});
+  preProcessInfo.setPreProcessChannel(rgb.b, {'stdScale': std[rgb.b], 'meanValue': mean[rgb.b]});
+  preProcessInfo.setVariant('mean_value');
 
   console.log(`Check ${device_name} plugin version:`);
   showPluginVersions(core.getVersions(device_name));
@@ -245,12 +256,14 @@ async function main() {
     start_time = performance.now();
     infer_req = exec_net.createInferRequest();
     const input_blob = infer_req.getBlob(input_info.name());
-    let input_data;
-    if (!preprocess) {
-      input_data = new Uint8Array(input_blob.wmap());
-    } else {
-      input_data = new Float32Array(input_blob.wmap());
-    }
+    // let input_data;
+    // if (!preprocess) {
+    //   input_data = new Uint8Array(input_blob.wmap());
+    // } else {
+    //   input_data = new Float32Array(input_blob.wmap());
+    // }
+    
+    let input_data = new Float32Array(input_blob.wmap())
 
     image.scan(
         0, 0, image.bitmap.width, image.bitmap.height, function(x, y, idx) {

--- a/src/preprocess_info.cc
+++ b/src/preprocess_info.cc
@@ -218,10 +218,10 @@ Napi::Value PreProcessInfo::GetPreProcessChannel(
     ;
   }
 
-  size_t index = info[0].ToNumber().Int32Value();
+  int index = info[0].ToNumber().Int32Value();
   ie::PreProcessInfo& pre_info = _input_info->getPreProcess();
 
-  size_t number_of_channels = pre_info.getNumberOfChannels();
+  int number_of_channels = pre_info.getNumberOfChannels();
 
   if (number_of_channels == 0) {
     Napi::Error::New(env, "accessing pre-process when nothing was set.")
@@ -242,7 +242,6 @@ Napi::Value PreProcessInfo::GetPreProcessChannel(
   preprocess_channel.Set("meanValue", preProcessChannel->meanValue);
 
   ie::Blob::Ptr mean_data = preProcessChannel->meanData;
-  std::unique_ptr<ie::LockedMemory<void>> locked_memory_;
   ie::MemoryBlob::Ptr memory_mean_data = ie::as<ie::MemoryBlob>(mean_data);
   if (!memory_mean_data) {
     preprocess_channel.Set("meanData", env.Null());
@@ -300,12 +299,12 @@ void PreProcessInfo::SetPreProcessChannel(const Napi::CallbackInfo& info) {
     return;
   }
 
-  size_t index = info[0].ToNumber().Int32Value();
+  int index = info[0].ToNumber().Int32Value();
   Napi::Object new_channel = info[1].ToObject();
 
   ie::PreProcessInfo& pre_info = _input_info->getPreProcess();
 
-  size_t number_of_channels = pre_info.getNumberOfChannels();
+  int number_of_channels = pre_info.getNumberOfChannels();
 
   if (number_of_channels == 0) {
     Napi::Error::New(env, "accessing pre-process when nothing was set.")

--- a/test/network.js
+++ b/test/network.js
@@ -389,15 +389,18 @@ describe('Network Test', function() {
        let meanData = {desc: tensorDesc, data: typedArray1.buffer};
        preprocessInfo.setPreProcessChannel(
            0, {'stdScale': 127.5, 'meanValue': 127.5, 'meanData': meanData});
-       const perProcessChannel = preprocessInfo.getPreProcessChannel(0);
-       expect(perProcessChannel.meanValue).to.be.a('number').equal(127.5);
-       expect(perProcessChannel.stdScale).to.be.a('number').equal(127.5);
-       expect(new Float32Array(perProcessChannel.meanData)[0]).equal(32.0);
+       const preProcessChannel = preprocessInfo.getPreProcessChannel(0);
+       expect(preProcessChannel.meanValue).to.be.a('number').equal(127.5);
+       expect(preProcessChannel.stdScale).to.be.a('number').equal(127.5);
+       expect(new Float32Array(preProcessChannel.meanData)[0]).equal(32.0);
      });
 
   it('PreProcessInfo.setPreProcessChannel should should throw for wrong number of arguments',
      () => {
        const preprocessInfo = network.getInputsInfo()[0].getPreProcess();
+       const preProcessChannel = preprocessInfo.getPreProcessChannel(0);
+       console.log(new Float32Array(preProcessChannel.meanData)[0])
+
        expect(() => preprocessInfo.setPreProcessChannel(1)).to.throw(TypeError);
      });
 


### PR DESCRIPTION
I added using PreProcessingChannel API to the `hello_classification_node` in this PR. And the result shows that the `Preprocesschannel` works well. Please check the file `example/hello_classification_node/main.js`. OpenVINO version is 2021.1

With the command: `node main.js -m ../../models/squeezenet1.1/FP16/squeezenet1.1.xml -i test.png -d CPU -n 10`, the result is:
```
id of classprobability    label
-------   -------        -------
387       0.998859       lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens
294       0.000253       brown bear, bruin, Ursus arctos
277       0.000243       red fox, Vulpes vulpes
278       0.000180       kit fox, Vulpes macrotis
298       0.000084       mongoose
```
With the command: `node main.js -m ../../models/squeezenet1.1/FP16/squeezenet1.1.xml -i test.png --mean [10,10,10] --std [10,20,40] -d CPU -n 10`, the result is:
```
id of classprobability    label
-------   -------        -------
5         0.230962       electric ray, crampfish, numbfish, torpedo
850       0.061423       teddy, teddy bear
904       0.035352       window screen
6         0.030383       stingray
78        0.026189       tick
```
