### PR TITLE
Add Symbol.toStringTag for each class

### DIFF
--- a/include/blob.h
+++ b/include/blob.h
@@ -29,6 +29,7 @@ class Blob : public Napi::ObjectWrap<Blob> {
     return Memmap(info, WRITE);
   }
   Napi::Value Unmap(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   // Helpers
   const static int READ = 0;

--- a/include/core.h
+++ b/include/core.h
@@ -21,6 +21,7 @@ class Core : public Napi::ObjectWrap<Core> {
   Napi::Value ReadNetworkFromData(const Napi::CallbackInfo& info);
   Napi::Value LoadNetwork(const Napi::CallbackInfo& info);
   Napi::Value GetAvailableDevices(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   InferenceEngine::Core actual_;
 };

--- a/include/executable_network.h
+++ b/include/executable_network.h
@@ -23,6 +23,7 @@ class ExecutableNetwork : public Napi::ObjectWrap<ExecutableNetwork> {
   static Napi::FunctionReference constructor;
   // APIs
   Napi::Value CreateInferRequest(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   InferenceEngine::ExecutableNetwork actual_;
 };

--- a/include/infer_request.h
+++ b/include/infer_request.h
@@ -20,6 +20,7 @@ class InferRequest : public Napi::ObjectWrap<InferRequest> {
   Napi::Value GetBlob(const Napi::CallbackInfo& info);
   Napi::Value Infer(const Napi::CallbackInfo& info);
   Napi::Value StartAsync(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   InferenceEngine::InferRequest actual_;
 };

--- a/include/input_info.h
+++ b/include/input_info.h
@@ -25,6 +25,7 @@ class InputInfo : public Napi::ObjectWrap<InputInfo> {
   void SetLayout(const Napi::CallbackInfo& info);
   Napi::Value GetDims(const Napi::CallbackInfo& info);
   Napi::Value GetPreProcess(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   InferenceEngine::InputInfo::Ptr actual_;
 };

--- a/include/network.h
+++ b/include/network.h
@@ -27,6 +27,7 @@ class Network : public Napi::ObjectWrap<Network> {
   Napi::Value GetName(const Napi::CallbackInfo& info);
   Napi::Value GetInputsInfo(const Napi::CallbackInfo& info);
   Napi::Value GetOutputsInfo(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   std::string model_;
   std::string weights_;

--- a/include/output_info.h
+++ b/include/output_info.h
@@ -22,6 +22,7 @@ class OutputInfo : public Napi::ObjectWrap<OutputInfo> {
   void SetPrecision(const Napi::CallbackInfo& info);
   Napi::Value GetLayout(const Napi::CallbackInfo& info);
   Napi::Value GetDims(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   InferenceEngine::DataPtr actual_;
 };

--- a/include/preprocess_info.h
+++ b/include/preprocess_info.h
@@ -27,6 +27,7 @@ class PreProcessInfo : public Napi::ObjectWrap<PreProcessInfo> {
   Napi::Value GetMeanVariant(const Napi::CallbackInfo& info);
   Napi::Value GetPreProcessChannel(const Napi::CallbackInfo& info);
   Napi::Value GetNumberOfChannels(const Napi::CallbackInfo& info);
+  Napi::Value toStringTag(const Napi::CallbackInfo& info);
 
   InferenceEngine::InputInfo::Ptr _input_info;
 };

--- a/src/blob.cc
+++ b/src/blob.cc
@@ -13,11 +13,16 @@ void Blob::Init(const Napi::Env& env) {
 
   Napi::Function func = DefineClass(
       env, "Blob",
-      {InstanceMethod("byteSize", &Blob::ByteSize),
-       InstanceMethod("size", &Blob::Size), InstanceMethod("rmap", &Blob::Rmap),
-       InstanceMethod("rwmap", &Blob::Rwmap),
-       InstanceMethod("wmap", &Blob::Wmap),
-       InstanceMethod("unmap", &Blob::Unmap)});
+      {
+          InstanceMethod("byteSize", &Blob::ByteSize),
+          InstanceMethod("size", &Blob::Size),
+          InstanceMethod("rmap", &Blob::Rmap),
+          InstanceMethod("rwmap", &Blob::Rwmap),
+          InstanceMethod("wmap", &Blob::Wmap),
+          InstanceMethod("unmap", &Blob::Unmap),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &Blob::toStringTag, nullptr, napi_enumerable),
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -99,6 +104,10 @@ Napi::Value Blob::Size(const Napi::CallbackInfo& info) {
     return Napi::Object::New(env);
   }
   return Napi::Number::New(env, actual_->size());
+}
+
+Napi::Value Blob::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "Blob");
 }
 
 }  // namespace ienodejs

--- a/src/core.cc
+++ b/src/core.cc
@@ -20,11 +20,15 @@ void Core::Init(const Napi::Env& env, Napi::Object exports) {
 
   Napi::Function func = DefineClass(
       env, "Core",
-      {InstanceMethod("getVersions", &Core::GetVersions),
-       InstanceMethod("readNetwork", &Core::ReadNetwork),
-       InstanceMethod("readNetworkFromData", &Core::ReadNetworkFromData),
-       InstanceMethod("loadNetwork", &Core::LoadNetwork),
-       InstanceMethod("getAvailableDevices", &Core::GetAvailableDevices)});
+      {
+          InstanceMethod("getVersions", &Core::GetVersions),
+          InstanceMethod("readNetwork", &Core::ReadNetwork),
+          InstanceMethod("readNetworkFromData", &Core::ReadNetworkFromData),
+          InstanceMethod("loadNetwork", &Core::LoadNetwork),
+          InstanceMethod("getAvailableDevices", &Core::GetAvailableDevices),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &Core::toStringTag, nullptr, napi_enumerable),
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -196,6 +200,10 @@ Napi::Value Core::GetAvailableDevices(const Napi::CallbackInfo& info) {
 
   Napi::Value available_devices = Napi::Value::From(env, devices);
   return available_devices;
+}
+
+Napi::Value Core::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "Core");
 }
 
 }  // namespace ienodejs

--- a/src/executable_network.cc
+++ b/src/executable_network.cc
@@ -66,10 +66,15 @@ Napi::FunctionReference ExecutableNetwork::constructor;
 void ExecutableNetwork::Init(const Napi::Env& env) {
   Napi::HandleScope scope(env);
 
-  Napi::Function func =
-      DefineClass(env, "ExecutableNetwork",
-                  {InstanceMethod("createInferRequest",
-                                  &ExecutableNetwork::CreateInferRequest)});
+  Napi::Function func = DefineClass(
+      env, "ExecutableNetwork",
+      {
+          InstanceMethod("createInferRequest",
+                         &ExecutableNetwork::CreateInferRequest),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &ExecutableNetwork::toStringTag, nullptr,
+                           napi_enumerable),
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -106,6 +111,10 @@ Napi::Value ExecutableNetwork::CreateInferRequest(
         .ThrowAsJavaScriptException();
     return env.Null();
   }
+}
+
+Napi::Value ExecutableNetwork::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "ExecutableNetwork");
 }
 
 }  // namespace ienodejs

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -53,9 +53,14 @@ void InferRequest::Init(const Napi::Env& env) {
 
   Napi::Function func =
       DefineClass(env, "InferRequest",
-                  {InstanceMethod("getBlob", &InferRequest::GetBlob),
-                   InstanceMethod("infer", &InferRequest::Infer),
-                   InstanceMethod("startAsync", &InferRequest::StartAsync)});
+                  {
+                      InstanceMethod("getBlob", &InferRequest::GetBlob),
+                      InstanceMethod("infer", &InferRequest::Infer),
+                      InstanceMethod("startAsync", &InferRequest::StartAsync),
+                      InstanceAccessor(
+                          Napi::Symbol::WellKnown(env, "toStringTag"),
+                          &InferRequest::toStringTag, nullptr, napi_enumerable),
+                  });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -136,6 +141,10 @@ Napi::Value InferRequest::StartAsync(const Napi::CallbackInfo& info) {
   infer_worker->Queue();
 
   return deferred.Promise();
+}
+
+Napi::Value InferRequest::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "InferRequest");
 }
 
 }  // namespace ienodejs

--- a/src/input_info.cc
+++ b/src/input_info.cc
@@ -16,15 +16,19 @@ Napi::FunctionReference InputInfo::constructor;
 void InputInfo::Init(const Napi::Env& env) {
   Napi::HandleScope scope(env);
 
-  Napi::Function func =
-      DefineClass(env, "InputInfo",
-                  {InstanceMethod("name", &InputInfo::Name),
-                   InstanceMethod("getPrecision", &InputInfo::GetPrecision),
-                   InstanceMethod("setPrecision", &InputInfo::SetPrecision),
-                   InstanceMethod("getLayout", &InputInfo::GetLayout),
-                   InstanceMethod("setLayout", &InputInfo::SetLayout),
-                   InstanceMethod("getDims", &InputInfo::GetDims),
-                   InstanceMethod("getPreProcess", &InputInfo::GetPreProcess)});
+  Napi::Function func = DefineClass(
+      env, "InputInfo",
+      {
+          InstanceMethod("name", &InputInfo::Name),
+          InstanceMethod("getPrecision", &InputInfo::GetPrecision),
+          InstanceMethod("setPrecision", &InputInfo::SetPrecision),
+          InstanceMethod("getLayout", &InputInfo::GetLayout),
+          InstanceMethod("setLayout", &InputInfo::SetLayout),
+          InstanceMethod("getDims", &InputInfo::GetDims),
+          InstanceMethod("getPreProcess", &InputInfo::GetPreProcess),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &InputInfo::toStringTag, nullptr, napi_enumerable),
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -143,6 +147,10 @@ Napi::Value InputInfo::GetPreProcess(const Napi::CallbackInfo& info) {
   }
 
   return PreProcessInfo::NewInstance(env, actual_);
+}
+
+Napi::Value InputInfo::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "InputInfo");
 }
 
 }  // namespace ienodejs

--- a/src/network.cc
+++ b/src/network.cc
@@ -100,6 +100,8 @@ void Network::Init(const Napi::Env& env) {
           InstanceMethod("getName", &Network::GetName),
           InstanceMethod("getInputsInfo", &Network::GetInputsInfo),
           InstanceMethod("getOutputsInfo", &Network::GetOutputsInfo),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &Network::toStringTag, nullptr, napi_enumerable),
       });
 
   constructor = Napi::Persistent(func);
@@ -163,6 +165,10 @@ Napi::Value Network::GetOutputsInfo(const Napi::CallbackInfo& info) {
     js_outputs_info[i++] = OutputInfo::NewInstance(env, out.second);
   }
   return js_outputs_info;
+}
+
+Napi::Value Network::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "Network");
 }
 
 }  // namespace ienodejs

--- a/src/output_info.cc
+++ b/src/output_info.cc
@@ -15,15 +15,17 @@ Napi::FunctionReference OutputInfo::constructor;
 void OutputInfo::Init(const Napi::Env& env) {
   Napi::HandleScope scope(env);
 
-  Napi::Function func =
-      DefineClass(env, "OutputInfo",
-                  {
-                      InstanceMethod("name", &OutputInfo::Name),
-                      InstanceMethod("getPrecision", &OutputInfo::GetPrecision),
-                      InstanceMethod("setPrecision", &OutputInfo::SetPrecision),
-                      InstanceMethod("getLayout", &OutputInfo::GetLayout),
-                      InstanceMethod("getDims", &OutputInfo::GetDims),
-                  });
+  Napi::Function func = DefineClass(
+      env, "OutputInfo",
+      {
+          InstanceMethod("name", &OutputInfo::Name),
+          InstanceMethod("getPrecision", &OutputInfo::GetPrecision),
+          InstanceMethod("setPrecision", &OutputInfo::SetPrecision),
+          InstanceMethod("getLayout", &OutputInfo::GetLayout),
+          InstanceMethod("getDims", &OutputInfo::GetDims),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &OutputInfo::toStringTag, nullptr, napi_enumerable),
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -106,6 +108,10 @@ Napi::Value OutputInfo::GetDims(const Napi::CallbackInfo& info) {
     js_dims[i] = ie_dims[i];
   }
   return js_dims;
+}
+
+Napi::Value OutputInfo::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "OutputInfo");
 }
 
 }  // namespace ienodejs

--- a/src/preprocess_channel.cc
+++ b/src/preprocess_channel.cc
@@ -79,20 +79,26 @@ Napi::Value PreProcessChannel::GetMeanData(const Napi::CallbackInfo& info) {
   auto meanDataBuffer = buffer.Data();
   switch (tensorDesc.getPrecision()) {
     case ie::Precision::FP32:
-      memcpy(meanDataBuffer,
-             localMemory.as<const ie::PrecisionTrait<ie::Precision::FP32>::value_type*>(),
-             byteSize);
+      memcpy(
+          meanDataBuffer,
+          localMemory
+              .as<const ie::PrecisionTrait<ie::Precision::FP32>::value_type*>(),
+          byteSize);
       break;
     case ie::Precision::FP16:
     case ie::Precision::I16:
-      memcpy(meanDataBuffer,
-             localMemory.as<const ie::PrecisionTrait<ie::Precision::FP16>::value_type*>(),
-             byteSize);
+      memcpy(
+          meanDataBuffer,
+          localMemory
+              .as<const ie::PrecisionTrait<ie::Precision::FP16>::value_type*>(),
+          byteSize);
       break;
     case ie::Precision::U8:
-      memcpy(meanDataBuffer,
-             localMemory.as<const ie::PrecisionTrait<ie::Precision::U8>::value_type*>(),
-             byteSize);
+      memcpy(
+          meanDataBuffer,
+          localMemory
+              .as<const ie::PrecisionTrait<ie::Precision::U8>::value_type*>(),
+          byteSize);
       break;
     default:
       Napi::TypeError::New(env,

--- a/src/preprocess_info.cc
+++ b/src/preprocess_info.cc
@@ -33,6 +33,9 @@ void PreProcessInfo::Init(const Napi::Env& env) {
                          &PreProcessInfo::GetNumberOfChannels),
           InstanceMethod("getPreProcessChannel",
                          &PreProcessInfo::GetPreProcessChannel),
+          InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"),
+                           &PreProcessInfo::toStringTag, nullptr,
+                           napi_enumerable),
       });
 
   constructor = Napi::Persistent(func);
@@ -216,6 +219,10 @@ Napi::Value PreProcessInfo::GetPreProcessChannel(
   size_t index = info[0].ToNumber().Int32Value();
   ie::PreProcessInfo& pre_info = _input_info->getPreProcess();
   return PreProcessChannel::NewInstance(env, pre_info, index);
+}
+
+Napi::Value PreProcessInfo::toStringTag(const Napi::CallbackInfo& info) {
+  return Napi::String::From(info.Env(), "PreProcessInfo");
 }
 
 }  // namespace ienodejs


### PR DESCRIPTION
This PR can fix all the failed cases caused by using `String` to check class. 
The sample looks like:

```
  it('readNetwork should return a Network object', async () => {
    expect(await core.readNetwork(model_path, weights_path)).to.be.a('Network');
  });
```

This case is failed before the PR. And the PR fixes all similar failed test cases.