### PR TITLE
Use native API `StartAsync` to complete the inference 

### DIFF
--- a/include/infer_request.h
+++ b/include/infer_request.h
@@ -20,8 +20,11 @@ class InferRequest : public Napi::ObjectWrap<InferRequest> {
   Napi::Value GetBlob(const Napi::CallbackInfo& info);
   Napi::Value Infer(const Napi::CallbackInfo& info);
   Napi::Value StartAsync(const Napi::CallbackInfo& info);
+  void SetCompletionCallback(const Napi::CallbackInfo& info);
+  void NativeStartAsync(const Napi::CallbackInfo& info);
 
   InferenceEngine::InferRequest actual_;
+  Napi::ThreadSafeFunction _threadSafeFunction;
 };
 
 }  // namespace ienodejs


### PR DESCRIPTION
@artyomtugaryov Hi, I utilize your implementation for `StartAsync` with node-binding. It can run the inference successfully in my tests. 